### PR TITLE
Hotfix: go module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Swig is a robust, PostgreSQL-backed job queue system for Go applications, design
 ⚠️ **Alpha Status**: Swig is currently in alpha and actively being developed towards v1.0.0. The API may undergo changes during this phase. For stability in production environments, we strongly recommend pinning to a specific version:
 
 ```bash
-go get github.com/swig/swig-go@v0.0.1-alpha
+go get github.com/swig/swig-go@v0.0.4-alpha
+```
+import it like: 
+```go 
+import swig "github.com/glamboyosa/swig/swig-go"
 ```
 
 ## Why Transactional Integrity Matters
@@ -76,7 +80,7 @@ Benefits of transactional job enqueueing:
 ## Installation
 
 ```bash
-go get github.com/swig/swig-go
+go get github.com/glamboyosa/swig/swig-go
 ```
 
 ## Supported Drivers
@@ -125,8 +129,8 @@ import (
     "github.com/jackc/pgx/v5/pgxpool"
     "database/sql"
     _ "github.com/lib/pq"
-    "github.com/swig/swig-go"
     "github.com/swig/swig-go/drivers"
+    import swig "github.com/glamboyosa/swig/swig-go"
 )
 
 // 1. Define your worker (as shown above in Understanding Workers)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,3 @@
+module examples
+
+go 1.23.2

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,3 +1,11 @@
 module examples
 
-go 1.23.2
+go 1.21
+
+require (
+	//swig v0.0.0
+	github.com/jackc/pgx/v5 v5.5.5
+	github.com/lib/pq v1.10.9
+)
+
+//replace swig => ../swig-go

--- a/swig-go/README.md
+++ b/swig-go/README.md
@@ -5,7 +5,11 @@ This directory contains the Go implementation of Swig. For full documentation, e
 ⚠️ **Alpha Status**: This implementation is currently in alpha. While it's being used in production, the API may change before v1.0.0. Pin to a specific version for stability:
 
 ```bash
-go get github.com/swig/swig-go@v0.0.1-alpha
+go get github.com/swig/swig-go@v0.0.4-alpha
+```
+import it like: 
+```go 
+import swig "github.com/glamboyosa/swig/swig-go"
 ```
 
 ## Quick Links
@@ -33,7 +37,7 @@ go get github.com/swig/swig-go@v0.0.1-alpha
 ## Installation
 
 ```bash
-go get github.com/swig/swig-go
+go get github.com/glamboyosa/swig/swig-go
 ```
 
 ## Supported Drivers
@@ -58,8 +62,8 @@ import (
     "github.com/jackc/pgx/v5/pgxpool"
     "database/sql"
     _ "github.com/lib/pq"
-    "github.com/swig/swig-go"
     "github.com/swig/swig-go/drivers"
+    import swig "github.com/glamboyosa/swig/swig-go"
 )
 
 // Define a worker

--- a/swig-go/go.mod
+++ b/swig-go/go.mod
@@ -1,4 +1,4 @@
-module swig
+module github.com/glamboyosa/swig/swig-go
 
 go 1.23.2
 

--- a/swig-go/swig.go
+++ b/swig-go/swig.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"swig/drivers"
-	"swig/workers"
 	"time"
+
+	"github.com/glamboyosa/swig/swig-go/drivers"
+	"github.com/glamboyosa/swig/swig-go/workers"
 )
 
 type QueueTypes string


### PR DESCRIPTION
We had the project as swig but it was in swig-go so downloading would not work.