### PR TITLE
Check for errors from PGX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Swig is a robust, PostgreSQL-backed job queue system for Go applications, design
 ⚠️ **Alpha Status**: Swig is currently in alpha and actively being developed towards v1.0.0. The API may undergo changes during this phase. For stability in production environments, we strongly recommend pinning to a specific version:
 
 ```bash
-go get github.com/glamboyosa/swig@v0.1.11-alpha
+go get github.com/glamboyosa/swig@v0.1.12-alpha
 ```
 import it like: 
 ```go 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Swig is a robust, PostgreSQL-backed job queue system for Go applications, design
 ⚠️ **Alpha Status**: Swig is currently in alpha and actively being developed towards v1.0.0. The API may undergo changes during this phase. For stability in production environments, we strongly recommend pinning to a specific version:
 
 ```bash
-go get github.com/glamboyosa/swig@v0.1.10-alpha
+go get github.com/glamboyosa/swig@v0.1.11-alpha
 ```
 import it like: 
 ```go 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/glamboyosa/swig/examples
 go 1.23.2
 
 require (
-	github.com/glamboyosa/swig v0.1.9-alpha
+	github.com/glamboyosa/swig v0.1.11-alpha
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lib/pq v1.10.9
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -7,6 +7,10 @@ github.com/glamboyosa/swig v0.1.7-alpha h1:n4siQ/5Hweiv0FIDqb7MTZl7vPrnaIfuQBzyE
 github.com/glamboyosa/swig v0.1.7-alpha/go.mod h1:V9LJDeF/YEy6n+H7duKd0MEd/5xaozBzFQwNtsCIIP8=
 github.com/glamboyosa/swig v0.1.9-alpha h1:3ckgRcQlHM8WbeuGUGJ9dBHTUXdnDsG2piD5F6aBdMU=
 github.com/glamboyosa/swig v0.1.9-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
+github.com/glamboyosa/swig v0.1.10-alpha h1:cOpQ08FpNDYNGwZgBdceS7/GHg+QdVoIz5AYwPFU8IM=
+github.com/glamboyosa/swig v0.1.10-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
+github.com/glamboyosa/swig v0.1.11-alpha h1:dC0RPbMKw1nqRWE0KnBUkLT6Az4Xv5fUB0KWowFCvb8=
+github.com/glamboyosa/swig v0.1.11-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/swig.go
+++ b/swig.go
@@ -587,7 +587,9 @@ func (s *Swig) processNextJob(ctx context.Context, queueType QueueTypes) error {
 	var payload []byte
 
 	err := s.driver.QueryRow(ctx, acquireSQL, string(queueType), s.workerID, workerID).Scan(&jobID, &kind, &payload)
-	if err == sql.ErrNoRows {
+
+	// Check for "no rows" errors from both database/sql and pgx
+	if err == sql.ErrNoRows || err != nil && (err.Error() == "no rows in result set" || err.Error() == "no rows in result") {
 		// No jobs available, wait for notification
 		notification, err := s.driver.WaitForNotification(ctx)
 		if err != nil {

--- a/swig.go
+++ b/swig.go
@@ -547,103 +547,144 @@ func (s *Swig) processNextJob(ctx context.Context, queueType QueueTypes) error {
 	// Generate unique worker ID for this job acquisition
 	workerID := pkg.GenerateWorkerID()
 
-	acquireSQL := `
-		UPDATE swig_jobs
-		SET status = 'processing',
-			instance_id = $2,        -- Track Swig instance
-			worker_id = $3,          -- Track specific worker
-			locked_at = NOW(),
-			attempts = attempts + 1
-		WHERE id = (
-			SELECT id
-			FROM swig_jobs
-			WHERE status = 'pending'
-				AND scheduled_for <= NOW()
-				AND (
-					(queue = 'priority' AND EXISTS (
-						SELECT 1 FROM swig_jobs 
-						WHERE queue = 'priority' 
-						AND status = 'pending'
-						AND scheduled_for <= NOW()
-					))
-					OR (queue = $1 AND NOT EXISTS (
-						SELECT 1 FROM swig_jobs 
-						WHERE queue = 'priority' 
-						AND status = 'pending'
-						AND scheduled_for <= NOW()
-					))
-				)
-			ORDER BY 
-				queue = 'priority' DESC,
-				priority DESC,
-				created_at
-			FOR UPDATE SKIP LOCKED
-			LIMIT 1
-		)
-		RETURNING id, kind, payload;`
-
-	var jobID string
-	var kind string
-	var payload []byte
-
-	err := s.driver.QueryRow(ctx, acquireSQL, string(queueType), s.workerID, workerID).Scan(&jobID, &kind, &payload)
-
 	// Check for "no rows" errors from both database/sql and pgx
-	if err == sql.ErrNoRows || err != nil && (err.Error() == "no rows in result set" || err.Error() == "no rows in result") {
-		// No jobs available, wait for notification
-		notification, err := s.driver.WaitForNotification(ctx)
+	acquireAndProcessJob := func(ctx context.Context, queueType QueueTypes, specificJobID string) error {
+		var acquireSQL string
+		var args []interface{}
+
+		if specificJobID != "" {
+			// Try to acquire a specific job first (from notification)
+			acquireSQL = `
+				UPDATE swig_jobs
+				SET status = 'processing',
+					instance_id = $1,
+					worker_id = $2,
+					locked_at = NOW(),
+					attempts = attempts + 1
+				WHERE id = $3
+					AND status = 'pending'
+					AND scheduled_for <= NOW()
+				RETURNING id, kind, payload;`
+			args = []interface{}{s.workerID, workerID, specificJobID}
+		} else {
+			// Otherwise try to acquire any job with priority handling
+			acquireSQL = `
+				UPDATE swig_jobs
+				SET status = 'processing',
+					instance_id = $1,
+					worker_id = $2,
+					locked_at = NOW(),
+					attempts = attempts + 1
+				WHERE id = (
+					SELECT id
+					FROM swig_jobs
+					WHERE status = 'pending'
+						AND scheduled_for <= NOW()
+						AND (
+							(queue = 'priority' AND EXISTS (
+								SELECT 1 FROM swig_jobs 
+								WHERE queue = 'priority' 
+								AND status = 'pending'
+								AND scheduled_for <= NOW()
+							))
+							OR (queue = $3 AND NOT EXISTS (
+								SELECT 1 FROM swig_jobs 
+								WHERE queue = 'priority' 
+								AND status = 'pending'
+								AND scheduled_for <= NOW()
+							))
+						)
+					ORDER BY 
+						queue = 'priority' DESC,
+						priority DESC,
+						created_at
+					FOR UPDATE SKIP LOCKED
+					LIMIT 1
+				)
+				RETURNING id, kind, payload;`
+			args = []interface{}{s.workerID, workerID, string(queueType)}
+		}
+
+		var jobID string
+		var kind string
+		var payload []byte
+
+		err := s.driver.QueryRow(ctx, acquireSQL, args...).Scan(&jobID, &kind, &payload)
+		if err == sql.ErrNoRows || err != nil && (err.Error() == "no rows in result set" || err.Error() == "no rows in result") {
+			return nil // No job available
+		}
 		if err != nil {
-			return fmt.Errorf("notification error: %w", err)
+			return fmt.Errorf("failed to acquire job: %w", err)
 		}
-		// Process notification if needed
-		_ = notification
-		return nil // Return nil here since this is normal behavior
-	}
-	if err != nil {
-		return fmt.Errorf("failed to acquire job: %w", err)
-	}
 
-	// Find the worker implementation
-	worker, ok := s.Workers.GetWorker(kind)
-	if !ok {
-		return fmt.Errorf("no worker registered for job type: %s", kind)
-	}
-
-	// Unmarshal the payload
-	if err := json.Unmarshal(payload, worker); err != nil {
-		return fmt.Errorf("failed to unmarshal job payload: %w", err)
-	}
-
-	// Process the job
-	err = worker.(interface{ Process(context.Context) error }).Process(ctx)
-
-	// Update job status based on processing result
-	if err != nil {
-		updateSQL := `
-			UPDATE swig_jobs
-			SET status = CASE 
-					WHEN attempts >= max_attempts THEN 'failed'
-					ELSE 'pending'
-				END,
-				last_error = $2,
-				last_error_at = NOW(),
-				instance_id = NULL,
-				worker_id = NULL,
-				locked_at = NULL
-			WHERE id = $1`
-		if err := s.driver.Exec(ctx, updateSQL, jobID, err.Error()); err != nil {
-			return fmt.Errorf("failed to update failed job: %w", err)
+		// Find the worker implementation
+		worker, ok := s.Workers.GetWorker(kind)
+		if !ok {
+			return fmt.Errorf("no worker registered for job type: %s", kind)
 		}
-	} else {
-		updateSQL := `
-			UPDATE swig_jobs
-			SET status = 'completed',
-				instance_id = NULL,
-				worker_id = NULL,
-				locked_at = NULL
-			WHERE id = $1`
-		if err := s.driver.Exec(ctx, updateSQL, jobID); err != nil {
-			return fmt.Errorf("failed to update completed job: %w", err)
+
+		// Unmarshal the payload
+		if err := json.Unmarshal(payload, worker); err != nil {
+			return fmt.Errorf("failed to unmarshal job payload: %w", err)
+		}
+
+		// Process the job
+		err = worker.(interface{ Process(context.Context) error }).Process(ctx)
+
+		// Update job status based on processing result
+		if err != nil {
+			updateSQL := `
+				UPDATE swig_jobs
+				SET status = CASE 
+						WHEN attempts >= max_attempts THEN 'failed'
+						ELSE 'pending'
+					END,
+					last_error = $2,
+					last_error_at = NOW(),
+					instance_id = NULL,
+					worker_id = NULL,
+					locked_at = NULL
+				WHERE id = $1`
+			if err := s.driver.Exec(ctx, updateSQL, jobID, err.Error()); err != nil {
+				return fmt.Errorf("failed to update failed job: %w", err)
+			}
+		} else {
+			updateSQL := `
+				UPDATE swig_jobs
+				SET status = 'completed',
+					instance_id = NULL,
+					worker_id = NULL,
+					locked_at = NULL
+				WHERE id = $1`
+			if err := s.driver.Exec(ctx, updateSQL, jobID); err != nil {
+				return fmt.Errorf("failed to update completed job: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// First try to acquire and process any job
+	err := acquireAndProcessJob(ctx, queueType, "")
+	if err != nil {
+		return err
+	}
+
+	// If no job was available, wait for notification
+	notification, err := s.driver.WaitForNotification(ctx)
+	if err != nil {
+		return fmt.Errorf("notification error: %w", err)
+	}
+
+	// Process the notification if we received one
+	if notification != nil && notification.Payload != "" {
+		// Try to parse the notification payload (should be JSON with job ID)
+		var notificationData struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(notification.Payload), &notificationData); err == nil && notificationData.ID != "" {
+			// Try to acquire and process the specific job from the notification
+			return acquireAndProcessJob(ctx, queueType, notificationData.ID)
 		}
 	}
 


### PR DESCRIPTION
## Overview
Once again, using examples dir to find bugs, this PR checks for PGX specific errors: "no rows in result set" which is expected when there's no jobs to process. So instead it should wait for a notification. It also fixes a bug where we never actually got awoken to run new jobs. So we first try and get a job and then we then wait for notification, get a job ID and then process the job. 