### PR TITLE
Fix SQL Example & Do not report context cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Swig is a robust, PostgreSQL-backed job queue system for Go applications, design
 ⚠️ **Alpha Status**: Swig is currently in alpha and actively being developed towards v1.0.0. The API may undergo changes during this phase. For stability in production environments, we strongly recommend pinning to a specific version:
 
 ```bash
-go get github.com/glamboyosa/swig@v0.1.12-alpha
+go get github.com/glamboyosa/swig@v0.1.13-alpha
 ```
 import it like: 
 ```go 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/glamboyosa/swig/examples
 go 1.23.2
 
 require (
-	github.com/glamboyosa/swig v0.1.11-alpha
+	github.com/glamboyosa/swig v0.1.12-alpha
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lib/pq v1.10.9
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -11,6 +11,8 @@ github.com/glamboyosa/swig v0.1.10-alpha h1:cOpQ08FpNDYNGwZgBdceS7/GHg+QdVoIz5AY
 github.com/glamboyosa/swig v0.1.10-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
 github.com/glamboyosa/swig v0.1.11-alpha h1:dC0RPbMKw1nqRWE0KnBUkLT6Az4Xv5fUB0KWowFCvb8=
 github.com/glamboyosa/swig v0.1.11-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
+github.com/glamboyosa/swig v0.1.12-alpha h1:OEG7os4W73wp45RUdhVnoI+8NWnhSF7IV3QugLTKO6I=
+github.com/glamboyosa/swig v0.1.12-alpha/go.mod h1:PmSNGpVi+f7WIzPv1d+CndtI8KJfyDo1K10JvDQ6yI8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
## Overview
This PR ensures we do not log context cancellation i.e. when a user interrupts and also a transaction bug in sql where we used map[string] as database/sql did not marshal it for us.