### PR TITLE
Improve worker lifecycle and PostgreSQL session handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Implementation details
 swig-implementation.md
 swig.md
+swig-interview-prep/
 # Binaries and build artifacts
 *.exe
 *.exe~

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,6 +24,8 @@ type Driver interface {
 	// New method to handle external transactions
 	AddJobWithTx(ctx context.Context, tx interface{}) (Transaction, error)
 	WaitForNotification(ctx context.Context) (*Notification, error)
+	NewListener(ctx context.Context, channel string) (Listener, error)
+	TryAdvisoryLock(ctx context.Context, lockID int64) (AdvisoryLock, bool, error)
 	AddJobsWithTx(ctx context.Context, tx interface{}, jobs []BatchJob) error
 }
 
@@ -31,6 +34,21 @@ type Transaction interface {
 	Exec(ctx context.Context, sql string, args ...interface{}) error
 	Query(ctx context.Context, sql string, args ...interface{}) (Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...interface{}) Row
+}
+
+// Listener represents a dedicated PostgreSQL LISTEN session.
+type Listener interface {
+	WaitForNotification(ctx context.Context) (*Notification, error)
+	Close(ctx context.Context) error
+}
+
+// AdvisoryLock represents a session-scoped advisory lock held on one connection.
+type AdvisoryLock interface {
+	Exec(ctx context.Context, sql string, args ...interface{}) error
+	Query(ctx context.Context, sql string, args ...interface{}) (Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) Row
+	Unlock(ctx context.Context) error
+	Close(ctx context.Context) error
 }
 
 // PgxTx represents a pgx transaction that can be passed in
@@ -75,4 +93,8 @@ type JobOptions struct {
 	Queue    string
 	Priority int
 	RunAt    time.Time
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
 }

--- a/drivers/pgx.go
+++ b/drivers/pgx.go
@@ -15,6 +15,16 @@ type PgxDriver struct {
 	pool *pgxpool.Pool
 }
 
+type pgxListener struct {
+	conn    *pgxpool.Conn
+	channel string
+}
+
+type pgxAdvisoryLock struct {
+	conn   *pgxpool.Conn
+	lockID int64
+}
+
 type pgxTxAdapter struct {
 	tx pgx.Tx
 }
@@ -51,6 +61,51 @@ func (tx *pgxTxAdapter) Query(ctx context.Context, sql string, args ...interface
 
 func (tx *pgxTxAdapter) QueryRow(ctx context.Context, sql string, args ...interface{}) Row {
 	return tx.tx.QueryRow(ctx, sql, args...)
+}
+
+func (l *pgxListener) WaitForNotification(ctx context.Context) (*Notification, error) {
+	notification, err := l.conn.Conn().WaitForNotification(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("wait for notification error: %w", err)
+	}
+
+	return &Notification{
+		Channel: notification.Channel,
+		Payload: notification.Payload,
+	}, nil
+}
+
+func (l *pgxListener) Close(ctx context.Context) error {
+	defer l.conn.Release()
+	_, err := l.conn.Exec(ctx, "UNLISTEN "+quoteIdentifier(l.channel))
+	return err
+}
+
+func (l *pgxAdvisoryLock) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := l.conn.Exec(ctx, sql, args...)
+	return err
+}
+
+func (l *pgxAdvisoryLock) Query(ctx context.Context, sql string, args ...interface{}) (Rows, error) {
+	rows, err := l.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &pgxRowsAdapter{rows: rows}, nil
+}
+
+func (l *pgxAdvisoryLock) QueryRow(ctx context.Context, sql string, args ...interface{}) Row {
+	return l.conn.QueryRow(ctx, sql, args...)
+}
+
+func (l *pgxAdvisoryLock) Unlock(ctx context.Context) error {
+	_, err := l.conn.Exec(ctx, `SELECT pg_advisory_unlock($1)`, l.lockID)
+	return err
+}
+
+func (l *pgxAdvisoryLock) Close(ctx context.Context) error {
+	defer l.conn.Release()
+	return l.Unlock(ctx)
 }
 
 // NewPgxDriver creates a new pgx-based driver implementation for PostgreSQL.
@@ -109,7 +164,7 @@ func (d *PgxDriver) QueryRow(ctx context.Context, sql string, args ...interface{
 }
 
 func (d *PgxDriver) Listen(ctx context.Context, channel string) error {
-	_, err := d.pool.Exec(ctx, "LISTEN "+channel)
+	_, err := d.pool.Exec(ctx, "LISTEN "+quoteIdentifier(channel))
 	return err
 }
 
@@ -144,6 +199,43 @@ func (d *PgxDriver) WaitForNotification(ctx context.Context) (*Notification, err
 		Channel: pgxNotification.Channel,
 		Payload: pgxNotification.Payload,
 	}, nil
+}
+
+// NewListener creates a dedicated connection for LISTEN/NOTIFY. PostgreSQL
+// listeners are session-scoped, so the same connection must both LISTEN and wait.
+func (d *PgxDriver) NewListener(ctx context.Context, channel string) (Listener, error) {
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire listener connection: %w", err)
+	}
+
+	if _, err := conn.Exec(ctx, "LISTEN "+quoteIdentifier(channel)); err != nil {
+		conn.Release()
+		return nil, fmt.Errorf("failed to listen on %s: %w", channel, err)
+	}
+
+	return &pgxListener{conn: conn, channel: channel}, nil
+}
+
+// TryAdvisoryLock acquires a session-scoped advisory lock on a dedicated
+// connection and returns that connection wrapped as the lock owner.
+func (d *PgxDriver) TryAdvisoryLock(ctx context.Context, lockID int64) (AdvisoryLock, bool, error) {
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to acquire advisory lock connection: %w", err)
+	}
+
+	var acquired bool
+	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, lockID).Scan(&acquired); err != nil {
+		conn.Release()
+		return nil, false, fmt.Errorf("failed to acquire advisory lock: %w", err)
+	}
+	if !acquired {
+		conn.Release()
+		return nil, false, nil
+	}
+
+	return &pgxAdvisoryLock{conn: conn, lockID: lockID}, true, nil
 }
 
 // AddJobsWithTx adds multiple jobs as part of an existing transaction

--- a/drivers/sql.go
+++ b/drivers/sql.go
@@ -18,6 +18,15 @@ type SQLDriver struct {
 	connStr string
 }
 
+type sqlListener struct {
+	listener *pq.Listener
+}
+
+type sqlAdvisoryLock struct {
+	conn   *sql.Conn
+	lockID int64
+}
+
 type sqlTxAdapter struct {
 	tx *sql.Tx
 }
@@ -53,6 +62,57 @@ func (tx *sqlTxAdapter) Query(ctx context.Context, sql string, args ...interface
 
 func (tx *sqlTxAdapter) QueryRow(ctx context.Context, sql string, args ...interface{}) Row {
 	return tx.tx.QueryRowContext(ctx, sql, args...)
+}
+
+func (l *sqlListener) WaitForNotification(ctx context.Context) (*Notification, error) {
+	select {
+	case notification := <-l.listener.Notify:
+		if notification == nil {
+			return nil, fmt.Errorf("received nil notification")
+		}
+		return &Notification{
+			Channel: notification.Channel,
+			Payload: notification.Extra,
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (l *sqlListener) Close(ctx context.Context) error {
+	_ = ctx
+	if err := l.listener.UnlistenAll(); err != nil {
+		l.listener.Close()
+		return err
+	}
+	return l.listener.Close()
+}
+
+func (l *sqlAdvisoryLock) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := l.conn.ExecContext(ctx, sql, args...)
+	return err
+}
+
+func (l *sqlAdvisoryLock) Query(ctx context.Context, sql string, args ...interface{}) (Rows, error) {
+	rows, err := l.conn.QueryContext(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlRowsAdapter{rows: rows}, nil
+}
+
+func (l *sqlAdvisoryLock) QueryRow(ctx context.Context, sql string, args ...interface{}) Row {
+	return l.conn.QueryRowContext(ctx, sql, args...)
+}
+
+func (l *sqlAdvisoryLock) Unlock(ctx context.Context) error {
+	_, err := l.conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, l.lockID)
+	return err
+}
+
+func (l *sqlAdvisoryLock) Close(ctx context.Context) error {
+	defer l.conn.Close()
+	return l.Unlock(ctx)
 }
 
 // NewSQLDriver creates a new database/sql driver implementation for PostgreSQL.
@@ -113,7 +173,7 @@ func (d *SQLDriver) QueryRow(ctx context.Context, sql string, args ...interface{
 }
 
 func (d *SQLDriver) Listen(ctx context.Context, channel string) error {
-	_, err := d.db.ExecContext(ctx, "LISTEN "+channel)
+	_, err := d.db.ExecContext(ctx, "LISTEN "+quoteIdentifier(channel))
 	return err
 }
 
@@ -155,6 +215,47 @@ func (d *SQLDriver) WaitForNotification(ctx context.Context) (*Notification, err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// NewListener creates and subscribes a long-lived lib/pq listener.
+func (d *SQLDriver) NewListener(ctx context.Context, channel string) (Listener, error) {
+	_ = ctx
+	listener := pq.NewListener(d.connStr,
+		10*time.Second,
+		time.Minute,
+		func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				log.Printf("Listener error: %v\n", err)
+			}
+		})
+
+	if err := listener.Listen(channel); err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("failed to listen on %s: %w", channel, err)
+	}
+
+	return &sqlListener{listener: listener}, nil
+}
+
+// TryAdvisoryLock acquires a session-scoped advisory lock on a dedicated
+// database/sql connection and returns that connection wrapped as the lock owner.
+func (d *SQLDriver) TryAdvisoryLock(ctx context.Context, lockID int64) (AdvisoryLock, bool, error) {
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to acquire advisory lock connection: %w", err)
+	}
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, lockID).Scan(&acquired); err != nil {
+		conn.Close()
+		return nil, false, fmt.Errorf("failed to acquire advisory lock: %w", err)
+	}
+	if !acquired {
+		conn.Close()
+		return nil, false, nil
+	}
+
+	return &sqlAdvisoryLock{conn: conn, lockID: lockID}, true, nil
 }
 
 // AddJobsWithTx adds multiple jobs as part of an existing transaction

--- a/swig-docs/content/docs/03-configuration.mdx
+++ b/swig-docs/content/docs/03-configuration.mdx
@@ -73,6 +73,8 @@ workers.RegisterWorker(&ImageResizeWorker{})
 swigClient := swig.NewSwig(driver, configs, workers)
 ```
 
+The registry stores a factory for each worker type. Every claimed job gets a fresh worker instance before its JSON payload is unmarshaled, which avoids sharing mutable worker state across concurrent jobs.
+
 ## Job Options
 
 When adding jobs, you can specify various options:
@@ -238,12 +240,22 @@ Swig provides comprehensive error handling:
 - Maximum retry attempts can be configured
 - Error details are stored in the database for debugging
 
+## Connection Lifecycle
+
+Swig uses PostgreSQL features that are tied to a database session, so it keeps those responsibilities on dedicated connections:
+
+- Worker notifications use a long-lived `LISTEN/NOTIFY` listener per worker.
+- Leader election uses a dedicated advisory-lock connection for the active leader.
+- Shutdown cancels worker contexts, closes listeners, waits for workers, and releases the leader advisory lock from the same session that acquired it.
+
+Application queries and job inserts still use the normal driver pool. Dedicated connections are only used where PostgreSQL requires session ownership.
+
 ## Cleanup and Testing
 
 Swig provides methods for both graceful shutdown and complete cleanup:
 
 ```go
-// Graceful shutdown: Wait for jobs to complete
+// Graceful shutdown: cancel workers, wait for them, and release leader resources
 err := swigClient.Stop(ctx)
 
 // Complete cleanup: Drop all Swig tables

--- a/swig-docs/content/docs/05-api.mdx
+++ b/swig-docs/content/docs/05-api.mdx
@@ -134,7 +134,34 @@ type Driver interface {
     Notify(ctx context.Context, channel string, payload string) error
     AddJobWithTx(ctx context.Context, tx interface{}) (Transaction, error)
     WaitForNotification(ctx context.Context) (*Notification, error)
+    NewListener(ctx context.Context, channel string) (Listener, error)
+    TryAdvisoryLock(ctx context.Context, lockID int64) (AdvisoryLock, bool, error)
     AddJobsWithTx(ctx context.Context, tx interface{}, jobs []BatchJob) error
+}
+```
+
+### Listener
+
+`Listener` represents a dedicated PostgreSQL `LISTEN/NOTIFY` session:
+
+```go
+type Listener interface {
+    WaitForNotification(ctx context.Context) (*Notification, error)
+    Close(ctx context.Context) error
+}
+```
+
+### AdvisoryLock
+
+`AdvisoryLock` represents a session-scoped PostgreSQL advisory lock:
+
+```go
+type AdvisoryLock interface {
+    Exec(ctx context.Context, sql string, args ...interface{}) error
+    Query(ctx context.Context, sql string, args ...interface{}) (Rows, error)
+    QueryRow(ctx context.Context, sql string, args ...interface{}) Row
+    Unlock(ctx context.Context) error
+    Close(ctx context.Context) error
 }
 ```
 

--- a/swig-docs/content/docs/06-advanced.mdx
+++ b/swig-docs/content/docs/06-advanced.mdx
@@ -61,27 +61,43 @@ err := swigClient.AddJob(ctx, &EmailWorker{
 ## Benefits of Transactional Job Processing
 
 - **No Lost Jobs**: Jobs are either fully committed or not at all
-- **Atomic Processing**: Jobs are processed exactly once using PostgreSQL's SKIP LOCK
+- **Atomic Claiming**: Workers claim jobs with PostgreSQL's `SKIP LOCKED` row locks
 - **Data Consistency**: Jobs can be part of your application's transactions
 
 ## Architecture
 
 Swig uses PostgreSQL's advanced features for efficient job distribution:
 
-### SKIP LOCK for Job Distribution
+### Worker Factories
 
-Swig uses PostgreSQL's SKIP LOCK feature to ensure:
+Workers are registered once by job name, but Swig creates a fresh worker instance for each claimed job before unmarshaling the job payload. This keeps concurrent jobs from mutating the same registered worker value.
+
+### SKIP LOCKED for Job Distribution
+
+Swig uses PostgreSQL's `FOR UPDATE SKIP LOCKED` feature to ensure:
 - No duplicate job processing
 - Fair job distribution across workers
 - High availability
 - Transactional integrity
 
+The row lock plays a similar coordination role to a mutex, but at the database level. A Go mutex protects memory inside one process. PostgreSQL row locks protect shared job rows across processes and machines.
+
+### Dedicated LISTEN/NOTIFY Connections
+
+PostgreSQL `LISTEN` is session-scoped. A listener must wait for notifications on the same connection that executed `LISTEN`.
+
+Swig now creates a dedicated listener for each worker. The listener stays open for the worker lifetime, receives `swig_jobs` notifications, and is closed during shutdown. This avoids subtle connection-pool bugs where `LISTEN` happens on one pooled connection but notification waiting happens on another.
+
 ### Leader Election
 
 Built-in leader election using PostgreSQL advisory locks ensures:
-- Only one worker processes jobs at a time
+- Only one Swig instance performs leader duties at a time
 - Automatic failover if the leader fails
 - No external coordination needed
+
+Advisory locks are also session-scoped, so Swig acquires the leader lock on a dedicated connection and keeps that connection open while leader duties run. On shutdown, Swig releases the advisory lock from the same session that acquired it.
+
+Instances that do not become leader keep retrying leadership in the background. If the active leader connection dies, PostgreSQL releases the advisory lock and another Swig instance can acquire leadership on a later retry.
 
 ## Batch Processing
 
@@ -204,7 +220,7 @@ Swig supports two PostgreSQL drivers with different characteristics:
 Swig provides methods for both graceful shutdown and complete cleanup:
 
 ```go
-// Graceful shutdown: Wait for jobs to complete
+// Graceful shutdown: cancel workers, wait for them, and release leader resources
 err := swigClient.Stop(ctx)
 
 // Complete cleanup: Drop all Swig tables

--- a/swig-docs/content/docs/index.mdx
+++ b/swig-docs/content/docs/index.mdx
@@ -29,10 +29,10 @@ go get github.com/glamboyosa/swig@v0.1.17-alpha
 Swig leverages PostgreSQL's powerful features to provide a robust job queue solution:
 
 - **Self-Hosted**: No external services required - just your existing PostgreSQL database
-- **Transactional Guarantees**: Jobs are processed exactly once with ACID compliance
-- **Built-in Queue Management**: Uses PostgreSQL's SKIP LOCK for efficient job distribution
-- **Leader Election**: Automatic leader election using PostgreSQL advisory locks
-- **Real-time Notifications**: Native LISTEN/NOTIFY support for immediate job processing
+- **Transactional Guarantees**: Enqueue jobs in the same transaction as your application data
+- **Built-in Queue Management**: Uses PostgreSQL's `SKIP LOCKED` for efficient job distribution
+- **Leader Election**: Automatic leader election using session-scoped PostgreSQL advisory locks
+- **Real-time Notifications**: Dedicated `LISTEN/NOTIFY` connections for immediate job processing
 - **Scalability**: Process jobs across multiple machines without external coordination
 
 ## Quick Start

--- a/swig.go
+++ b/swig.go
@@ -22,10 +22,10 @@ const (
 	Default  QueueTypes = "default"
 	Priority QueueTypes = "priority"
 
-	leaderLockID  = 1234567 // Arbitrary number for advisory lock
-	leaderKey     = "queue_leader"
-	leaderTTL     = 30 * time.Second
-	retryInterval = 5 * time.Second
+	leaderLockID  int64 = 1234567 // Arbitrary number for advisory lock
+	leaderKey           = "queue_leader"
+	leaderTTL           = 30 * time.Second
+	retryInterval       = 5 * time.Second
 )
 
 // minimum number of workers to start
@@ -43,9 +43,13 @@ type Swig struct {
 	driver          drivers.Driver
 	Workers         workers.WorkerRegistry
 	activeWorkers   sync.WaitGroup // Track active workers
-	shutdown        chan struct{}  // Signal for graceful shutdown
-	leaderID        string         // Current leader ID if we're the leader
-	workerID        string         // Unique ID for this worker instance
+	leaderMu        sync.Mutex
+	stopOnce        sync.Once     // Make shutdown safe to call once or many times
+	shutdown        chan struct{} // Signal for graceful shutdown
+	workerCancel    context.CancelFunc
+	leaderLock      drivers.AdvisoryLock
+	leaderID        string // Current leader ID if we're the leader
+	workerID        string // Unique ID for this worker instance
 }
 
 // NewSwig creates a new job queue instance with the specified database driver,
@@ -77,57 +81,122 @@ func NewSwig(driver drivers.Driver, swigQueueConfig []SwigQueueConfig, workers w
 }
 
 // tryBecomeLeader attempts to acquire leadership using advisory locks
-func (s *Swig) tryBecomeLeader(ctx context.Context) error {
-	// Try to acquire advisory lock
-	var acquired bool
-	err := s.driver.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, leaderLockID).Scan(&acquired)
-	if err != nil || !acquired {
-		return fmt.Errorf("failed to acquire leader lock: %w", err)
+func (s *Swig) tryBecomeLeader(ctx context.Context) (drivers.AdvisoryLock, bool, error) {
+	lock, acquired, err := s.driver.TryAdvisoryLock(ctx, leaderLockID)
+	if err != nil {
+		return nil, false, err
+	}
+	if !acquired {
+		return nil, false, nil
 	}
 
 	// If we got the lock, update the leader table
-	s.leaderID = pkg.GenerateWorkerID()
-	err = s.driver.Exec(ctx, `
+	leaderID := pkg.GenerateWorkerID()
+	err = lock.Exec(ctx, `
 		INSERT INTO swig_leader (id, leader_id, expires_at)
 		VALUES ($1, $2, NOW() + $3::interval)
 		ON CONFLICT (id) DO UPDATE
 		SET leader_id = $2,
 			expires_at = NOW() + $3::interval
-	`, leaderKey, s.leaderID, leaderTTL.String())
+	`, leaderKey, leaderID, leaderTTL.String())
 
 	if err != nil {
-		// Release the advisory lock if we couldn't update the table
-		s.driver.Exec(ctx, `SELECT pg_advisory_unlock($1)`, leaderLockID)
-		return fmt.Errorf("failed to update leader record: %w", err)
+		if closeErr := lock.Close(ctx); closeErr != nil {
+			log.Printf("Failed to release leader lock after setup error: %v", closeErr)
+		}
+		return nil, false, fmt.Errorf("failed to update leader record: %w", err)
 	}
 
-	// Start leader duties in background
-	go s.performLeaderDuties(ctx)
+	s.leaderMu.Lock()
+	s.leaderID = leaderID
+	s.leaderLock = lock
+	s.leaderMu.Unlock()
 
-	return nil
+	return lock, true, nil
 }
 
-// performLeaderDuties handles leader responsibilities like retrying failed jobs
-func (s *Swig) performLeaderDuties(ctx context.Context) {
+func (s *Swig) startLeaderElection(ctx context.Context) {
 	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 
 	for {
+		lock, acquired, err := s.tryBecomeLeader(ctx)
+		if err != nil {
+			log.Printf("Failed to become leader: %v", err)
+		}
+		if acquired {
+			log.Printf("Acquired Swig leadership")
+			if err := s.performLeaderDuties(ctx, lock); err != nil {
+				log.Printf("Leader duties stopped: %v", err)
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			return
 		case <-s.shutdown:
 			return
 		case <-ticker.C:
-			if err := s.retryFailedJobs(ctx); err != nil {
-				log.Printf("Error retrying failed jobs: %v", err)
+		}
+	}
+}
+
+func (s *Swig) releaseLeader(ctx context.Context, lock drivers.AdvisoryLock) {
+	s.leaderMu.Lock()
+	if lock == nil {
+		lock = s.leaderLock
+	}
+	if lock == nil || lock != s.leaderLock {
+		s.leaderMu.Unlock()
+		return
+	}
+
+	leaderID := s.leaderID
+	s.leaderID = ""
+	s.leaderLock = nil
+	s.leaderMu.Unlock()
+
+	if leaderID != "" {
+		unlockSQL := `
+			DELETE FROM swig_leader
+			WHERE leader_id = $1
+		`
+		if err := s.driver.Exec(ctx, unlockSQL, leaderID); err != nil {
+			log.Printf("Failed to delete leader record: %v", err)
+		}
+	}
+
+	if err := lock.Close(ctx); err != nil {
+		log.Printf("Failed to release advisory lock: %v", err)
+	}
+}
+
+// performLeaderDuties handles leader responsibilities like retrying failed jobs
+func (s *Swig) performLeaderDuties(ctx context.Context, lock drivers.AdvisoryLock) error {
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.releaseLeader(releaseCtx, lock)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-s.shutdown:
+			return nil
+		case <-ticker.C:
+			if err := s.retryFailedJobs(ctx, lock); err != nil {
+				return err
 			}
 		}
 	}
 }
 
 // retryFailedJobs finds failed jobs that can be retried and requeues them
-func (s *Swig) retryFailedJobs(ctx context.Context) error {
+func (s *Swig) retryFailedJobs(ctx context.Context, tx drivers.Transaction) error {
 	// Find failed jobs that haven't exceeded max attempts and apply backoff
 	retrySQL := `
 		UPDATE swig_jobs
@@ -155,7 +224,7 @@ func (s *Swig) retryFailedJobs(ctx context.Context) error {
 
 	var jobIDs []string
 	var totalAttempts int
-	rows, err := s.driver.Query(ctx, retrySQL)
+	rows, err := tx.Query(ctx, retrySQL)
 	if err != nil {
 		// Don't report context cancellation as an error - this is normal during shutdown
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -243,13 +312,19 @@ func (s *Swig) Start(ctx context.Context) {
 	-- Unlogged for better performance since this is temporary state
 	ALTER TABLE swig_leader SET UNLOGGED;`
 
-	s.driver.Exec(ctx, createTableSQL)
-	s.driver.Exec(ctx, createLeaderTableSQL)
-
-	// Try to become leader
-	if err := s.tryBecomeLeader(ctx); err != nil {
-		log.Printf("Failed to become leader: %v", err)
+	if err := s.driver.Exec(ctx, createTableSQL); err != nil {
+		log.Printf("Failed to create swig_jobs table: %v", err)
+		return
 	}
+	if err := s.driver.Exec(ctx, createLeaderTableSQL); err != nil {
+		log.Printf("Failed to create swig_leader table: %v", err)
+		return
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	s.workerCancel = cancel
+
+	go s.startLeaderElection(workerCtx)
 
 	// Start worker pools for each queue
 	for _, config := range s.swigQueueConfig {
@@ -263,7 +338,7 @@ func (s *Swig) Start(ctx context.Context) {
 			s.activeWorkers.Add(1)
 			go func(qType QueueTypes) {
 				defer s.activeWorkers.Done()
-				s.startWorker(ctx, qType)
+				s.startWorker(workerCtx, qType)
 			}(config.QueueType)
 		}
 	}
@@ -278,8 +353,13 @@ func (s *Swig) Stop(ctx context.Context) error {
 		defer cancel()
 	}
 
-	// Signal all workers to stop
-	close(s.shutdown)
+	// Signal all workers to stop. sync.Once makes Stop safe to call repeatedly.
+	s.stopOnce.Do(func() {
+		close(s.shutdown)
+		if s.workerCancel != nil {
+			s.workerCancel()
+		}
+	})
 
 	// Wait for all workers to finish their current jobs
 	done := make(chan struct{})
@@ -306,21 +386,7 @@ func (s *Swig) Stop(ctx context.Context) error {
 		log.Printf("Failed to cleanup instance jobs: %v", err)
 	}
 
-	// Release any leader locks we might be holding
-	if s.leaderID != "" {
-		unlockSQL := `
-			DELETE FROM swig_leader
-			WHERE leader_id = $1
-		`
-		if err := s.driver.Exec(ctx, unlockSQL, s.leaderID); err != nil {
-			log.Printf("Failed to release leader lock: %v", err)
-		}
-
-		// Also release the advisory lock
-		if err := s.driver.Exec(ctx, `SELECT pg_advisory_unlock($1)`, leaderLockID); err != nil {
-			log.Printf("Failed to release advisory lock: %v", err)
-		}
-	}
+	s.releaseLeader(ctx, nil)
 
 	// Close database connections cleanly
 	if closer, ok := s.driver.(interface{ Close() error }); ok {
@@ -527,19 +593,28 @@ func (s *Swig) AddJobWithTx(ctx context.Context, tx interface{}, workerWithArgs 
 // 2. Attempts to acquire and process jobs using SELECT FOR UPDATE SKIP LOCKED
 // 3. Handles job completion and failure
 func (s *Swig) startWorker(ctx context.Context, queueType QueueTypes) {
-	// Start listening for notifications
-	if err := s.driver.Listen(ctx, "swig_jobs"); err != nil {
+	listener, err := s.driver.NewListener(ctx, "swig_jobs")
+	if err != nil {
 		log.Printf("Failed to start listening: %v", err)
 		return
 	}
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := listener.Close(closeCtx); err != nil {
+			log.Printf("Failed to close listener: %v", err)
+		}
+	}()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-s.shutdown:
+			return
 		default:
 			// Try to acquire and process a job
-			if err := s.processNextJob(ctx, queueType); err != nil {
+			if err := s.processNextJob(ctx, queueType, listener); err != nil {
 				log.Printf("Error processing job: %v", err)
 				// Small backoff on error
 				time.Sleep(time.Second)
@@ -549,7 +624,7 @@ func (s *Swig) startWorker(ctx context.Context, queueType QueueTypes) {
 }
 
 // processNextJob attempts to acquire and process the next available job using SKIP LOCKED
-func (s *Swig) processNextJob(ctx context.Context, queueType QueueTypes) error {
+func (s *Swig) processNextJob(ctx context.Context, queueType QueueTypes, listener drivers.Listener) error {
 	// Generate unique worker ID for this job acquisition
 	workerID := pkg.GenerateWorkerID()
 
@@ -677,7 +752,7 @@ func (s *Swig) processNextJob(ctx context.Context, queueType QueueTypes) error {
 	}
 
 	// If no job was available, wait for notification
-	notification, err := s.driver.WaitForNotification(ctx)
+	notification, err := listener.WaitForNotification(ctx)
 	if err != nil {
 		// Don't report context cancellation as an error - this is normal during shutdown
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -3,8 +3,14 @@ package workers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 )
+
+type runtimeWorker interface {
+	JobName() string
+	Process(context.Context) error
+}
 
 type Job[T any] struct {
 	ID        string
@@ -25,7 +31,7 @@ type Job[T any] struct {
 // TODO: Implement polling fallback for environments where LISTEN/NOTIFY
 // is not available or configured.
 type WorkerRegistry struct {
-	workers map[string]interface{} // stores Worker[T] instances
+	workers map[string]func() interface{}
 }
 
 type Worker[T any] interface {
@@ -35,7 +41,7 @@ type Worker[T any] interface {
 
 func NewWorkerRegistry() *WorkerRegistry {
 	return &WorkerRegistry{
-		workers: make(map[string]interface{}),
+		workers: make(map[string]func() interface{}),
 	}
 }
 
@@ -43,17 +49,48 @@ func NewWorkerRegistry() *WorkerRegistry {
 // It accepts any type that implements the Worker interface and performs
 // runtime type checking to ensure the worker is properly implemented.
 func (wr *WorkerRegistry) RegisterWorker(worker interface{}) error {
-	// Type assert to check if it implements required methods
-	if w, ok := worker.(interface{ JobName() string }); !ok {
-		return fmt.Errorf("worker must implement JobName() string")
-	} else {
-		wr.workers[w.JobName()] = worker
+	w, ok := worker.(runtimeWorker)
+	if !ok {
+		if _, hasName := worker.(interface{ JobName() string }); !hasName {
+			return fmt.Errorf("worker must implement JobName() string")
+		}
+		return fmt.Errorf("worker must implement Process(context.Context) error")
+	}
+
+	workerType := reflect.TypeOf(worker)
+	if workerType == nil {
+		return fmt.Errorf("worker must not be nil")
+	}
+	workerValue := reflect.ValueOf(worker)
+	if workerType.Kind() == reflect.Ptr && workerValue.IsNil() {
+		return fmt.Errorf("worker must not be nil")
+	}
+
+	jobName := w.JobName()
+
+	if workerType.Kind() != reflect.Ptr {
+		wr.workers[jobName] = func() interface{} {
+			return worker
+		}
 		return nil
 	}
+
+	elemType := workerType.Elem()
+	if elemType.Kind() != reflect.Struct {
+		return fmt.Errorf("worker must be a pointer to a struct")
+	}
+
+	wr.workers[jobName] = func() interface{} {
+		return reflect.New(elemType).Interface()
+	}
+	return nil
 }
 
 // GetWorker retrieves a worker implementation by its job name
 func (wr *WorkerRegistry) GetWorker(jobName string) (interface{}, bool) {
-	worker, exists := wr.workers[jobName]
-	return worker, exists
+	factory, exists := wr.workers[jobName]
+	if !exists {
+		return nil, false
+	}
+	return factory(), true
 }


### PR DESCRIPTION
## Goal

Improve Swig's worker lifecycle and PostgreSQL session handling so `LISTEN/NOTIFY`, advisory-lock leadership, worker shutdown, and job payload handling behave correctly with pooled database connections.

## Screenshots

N/A. This PR changes backend lifecycle behavior and documentation.

## What I changed and why

- Added dedicated listener abstractions for `pgx` and `database/sql` so workers wait for notifications on the same PostgreSQL session that issued `LISTEN`.
- Added dedicated advisory lock abstractions so leader election holds and releases PostgreSQL advisory locks on the same session.
- Added background leader retry/failover so non-leader instances can acquire leadership if the active leader exits.
- Made `Stop` safer with cancellable worker contexts and `sync.Once` idempotency.
- Updated worker registration to create a fresh worker instance per job, avoiding shared mutable worker state across concurrent jobs.
- Updated `swig-docs` to document connection lifecycle, leader election, shutdown, and worker factory behavior.

## What I'm not doing here

- Not adding new database indexes.
- Not updating `examples/` yet.
- Not changing public job enqueueing APIs.
- Not adding full integration tests in this PR.

## LLM use disclosure
